### PR TITLE
Fix failing circleci build on jenkinsci: push not permitted

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,8 @@ jobs:
       - restore_cache: 
           key: meterian-plugin-{{ checksum "pom.xml" }}
       
-      - run: mvn dependency:go-offline 
+      - run: mvn dependency:go-offline
+      - run: mvn package -DskipTests || true
       
       - save_cache: 
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,7 @@ jobs:
       - save_cache: 
           paths:
             - ~/.m2
+            - ./target
           key: meterian-plugin-{{ checksum "pom.xml" }}
       
       - run: mvn package 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,8 +23,14 @@ jobs:
             - ./target
           key: meterian-plugin-{{ checksum "pom.xml" }}
       
-      - run: mvn package 
-      
+      - run:
+          name: Remove url rewriting git config and run 'mvn package'
+          command: |
+            ### See url-rewriting related post:
+            ###    https://stackoverflow.com/questions/33835669/jgit-sets-git-uri-instead-of-https-for-remote-on-circleci
+            git config --global --unset url.ssh://git@github.com.insteadof || true
+            mvn package
+
       - store_test_results: 
           path: target/surefire-reports
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# jenkins-plugin
+# meterian-scanner-plugin
 
 The official Meterian plugin for Jenkins.
 
@@ -66,6 +66,16 @@ Ensure the above two environment variables are set via https://circleci.com/gh/[
 
 In addition you would also need to add the SSH key associated with the Machine User created above to the CircleCI SSH keychain, see how that is done via https://circleci.com/docs/2.0/gh-bb-integration/#creating-a-machine-user.
 
+#### Known issue
+
+##### _push not permitted_ error message
+
+See post [URL rewriting SO post](https://stackoverflow.com/questions/33835669/jgit-sets-git-uri-instead-of-https-for-remote-on-circleci), can be overcome by inserting the below:
+```bash
+  git config --global --unset url.ssh://git@github.com.insteadof || true
+```
+
+in the `./circleci/config.yml` before the build or test runs to overcome this error message. 
 
 _**Note:** in general the above might not be needed if your CI/CD environment contains the necessary permission to perform `git push` related actions on the target repo you are analysing._
 

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -1,2 +1,2 @@
-mvn mvn -T1C -am \
-        -Djna.nosys=true clean package
+mvn -T1C -am \
+    -Djna.nosys=true clean package

--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -1,0 +1,2 @@
+work
+target

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,15 @@
+FROM maven:latest
+
+WORKDIR /home/
+
+COPY .  /home/
+
+ARG METERIAN_API_TOKEN
+ENV METERIAN_API_TOKEN=${METERIAN_API_TOKEN}
+
+ARG METERIAN_GITHUB_TOKEN
+ENV METERIAN_GITHUB_TOKEN=${METERIAN_GITHUB_TOKEN}
+
+RUN mvn dependency:go-offline
+
+RUN mvn package -DskipTests || true

--- a/docker/buildDockerImage.sh
+++ b/docker/buildDockerImage.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+set -u
+set -o pipefail
+
+cd ..
+docker build                                                       \
+       --build-arg METERIAN_API_TOKEN=${METERIAN_API_TOKEN}        \
+       --build-arg METERIAN_GITHUB_TOKEN=${METERIAN_GITHUB_TOKEN}  \
+       -t meterian-scanner-plugin                                  \
+       -f docker/Dockerfile . || (true && cd -)

--- a/docker/removeUnusedContainersAndImages.sh
+++ b/docker/removeUnusedContainersAndImages.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -e
+set -u
+set -o pipefail
+
+containersToRemove=$(docker ps --quiet --filter "status=exited")
+[ ! -z "${containersToRemove}" ] && \
+    echo "Remove any stopped container from the local registry" && \
+    docker rm ${containersToRemove} || true
+
+imagesToRemove=$(docker images --quiet --filter "dangling=true")
+[ ! -z "${imagesToRemove}" ] && \
+    echo "Remove any dangling images from the local registry" && \
+    docker rmi -f ${imagesToRemove} || true

--- a/docker/runInDockerContainer.sh
+++ b/docker/runInDockerContainer.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+set -u
+set -o pipefail
+
+docker run -it                      \
+           --workdir /home/         \
+           --volume $(pwd)/:/home/  \
+           meterian-scanner-plugin  \
+           /bin/bash

--- a/src/main/java/io/meterian/jenkins/autofixfeature/AutoFixFeature.java
+++ b/src/main/java/io/meterian/jenkins/autofixfeature/AutoFixFeature.java
@@ -38,6 +38,7 @@ public class AutoFixFeature {
         localGitClient = new LocalGitClient(
                 environment.get("WORKSPACE"),
                 configuration.getMeterianGithubUser(),
+                configuration.getMeterianGithubToken(),
                 configuration.getMeterianGithubEmail(),
                 jenkinsLogger);
     }

--- a/src/main/java/io/meterian/jenkins/autofixfeature/git/LocalGitClient.java
+++ b/src/main/java/io/meterian/jenkins/autofixfeature/git/LocalGitClient.java
@@ -353,7 +353,7 @@ public class LocalGitClient {
                         .collect(Collectors.toList()));
     }
 
-    private void addRemoteForHttpsURI(Git git) throws URISyntaxException, GitAPIException {
+    private void addRemoteForHttpsURI(Git git) throws URISyntaxException, GitAPIException, IOException {
         String repoURI = String.format(
                 "https://github.com/%s.git",
                 getRepositoryName()

--- a/src/main/java/io/meterian/jenkins/autofixfeature/git/LocalGitClient.java
+++ b/src/main/java/io/meterian/jenkins/autofixfeature/git/LocalGitClient.java
@@ -2,6 +2,7 @@ package io.meterian.jenkins.autofixfeature.git;
 
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.ListBranchCommand;
+import org.eclipse.jgit.api.RemoteAddCommand;
 import org.eclipse.jgit.api.ResetCommand;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.dircache.DirCache;
@@ -10,6 +11,7 @@ import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.transport.CredentialsProvider;
 import org.eclipse.jgit.transport.RemoteConfig;
+import org.eclipse.jgit.transport.URIish;
 import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -17,6 +19,7 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.net.URISyntaxException;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -28,6 +31,7 @@ public class LocalGitClient {
 
     private static final String REMOTE_BRANCH_ALREADY_EXISTS_WARNING = "[meterian] Warning: %s already exists in the remote repo, skipping the remote branch creation process.";
     private static final String FIXED_BY_METERIAN = "fixed-by-meterian";
+    private static final String HTTPS_ORIGIN = "https-origin";
 
     private final String meterianGithubUser;  // Machine User name
     private final String meterianGithubEmail; // Email associated with the Machine User
@@ -116,11 +120,13 @@ public class LocalGitClient {
             if (currentBranchWasCreatedByMeterianClient()) {
                 log.info(String.format("Checking if the branch %s to be created already exists in remote repo", currentBranch));
                 git().fetch()
+                        .setRemote(HTTPS_ORIGIN)
                         .setRemoveDeletedRefs(true)
                         .call();
                 if (meterianRemoteBranchDoesNotExists()) {
                     log.info(String.format("Branch %s does not exist in remote repo, started pushing branch", currentBranch));
                     git().push()
+                            .setRemote(HTTPS_ORIGIN)
                             .setCredentialsProvider(credentialsProvider)
                             .call();
                     log.info("Finished pushing branch to remote repo");
@@ -328,10 +334,34 @@ public class LocalGitClient {
             try {
                 this.git = Git.open(new File(pathToRepo));
                 log.info(String.format("Workspace is pointing to branch %s (%s)", getCurrentBranch(), getCurrentBranchSHA()));
+
+                addRemoteForHttpsURI(this.git);
+                enlistRemotes(this.git);
             } catch (Exception ex) {
                 throw new RuntimeException(ex);
             }
 
         return git;
+    }
+
+    private void enlistRemotes(Git git) throws GitAPIException {
+        List<RemoteConfig> remoteList = git.remoteList().call();
+        log.info("Remotes: " +
+                remoteList.stream()
+                        .map(remote -> String.format(
+                                "%s: uri: %s: pushUri: %s", remote.getName(), remote.getURIs(), remote.getPushURIs()))
+                        .collect(Collectors.toList()));
+    }
+
+    private void addRemoteForHttpsURI(Git git) throws URISyntaxException, GitAPIException {
+        String repoURI = String.format(
+                "https://github.com/%s.git",
+                getRepositoryName()
+        );
+        RemoteAddCommand remoteAddCommand = git.remoteAdd();
+        remoteAddCommand.setName(HTTPS_ORIGIN);
+        remoteAddCommand.setUri(new URIish(repoURI));
+        RemoteConfig remoteConfig = remoteAddCommand.call();
+        remoteConfig.addPushURI(new URIish(repoURI));
     }
 }

--- a/src/test/java/io/meterian/integration_tests/MeterianClientAutofixFeatureTest.java
+++ b/src/test/java/io/meterian/integration_tests/MeterianClientAutofixFeatureTest.java
@@ -61,7 +61,12 @@ public class MeterianClientAutofixFeatureTest {
         // Given: we are setup to run the meterian client against a repo that has vulnerabilities
         FileUtils.deleteDirectory(new File(gitRepoRootFolder));
         new File(gitRepoRootFolder).mkdir();
-        testManagement.performCloneGitRepo(githubOrgName, githubProjectName, gitRepoWorkingFolder, "master");
+        testManagement.performCloneGitRepo(
+                githubProjectName,
+                githubOrgName,
+                gitRepoWorkingFolder,
+                "master"
+        );
 
         // Deleting remote branch automatically closes any Pull Request attached to it
         testManagement.configureGitUserNameAndEmail(
@@ -175,7 +180,10 @@ public class MeterianClientAutofixFeatureTest {
         FileUtils.deleteDirectory(new File(gitRepoRootFolder));
         new File(gitRepoRootFolder).mkdir();
         testManagement.performCloneGitRepo(
-                githubOrgName, githubProjectName, gitRepoWorkingFolder, "partially-fixed-by-autofix");
+                githubProjectName,
+                githubOrgName,
+                gitRepoWorkingFolder,
+                "partially-fixed-by-autofix");
 
         // Deleting remote branch automatically closes any Pull Request attached to it
         testManagement.configureGitUserNameAndEmail(

--- a/src/test/java/io/meterian/integration_tests/MeterianClientAutofixFeatureTest.java
+++ b/src/test/java/io/meterian/integration_tests/MeterianClientAutofixFeatureTest.java
@@ -74,8 +74,6 @@ public class MeterianClientAutofixFeatureTest {
                 testManagement.getMeterianGithubEmail() == null ? "bot.github@meterian.io" : testManagement.getMeterianGithubEmail()
         );
 
-        testManagement.configureUnsetUrlRewriting();
-
         fixedByMeterianBranchName = testManagement.getFixedByMeterianBranchName(gitRepoWorkingFolder,"master");
         testManagement.deleteRemoteBranch(
                 gitRepoWorkingFolder,
@@ -202,8 +200,6 @@ public class MeterianClientAutofixFeatureTest {
                 testManagement.getMeterianGithubUser() == null ? "meterian-bot" : testManagement.getMeterianGithubUser(),
                 testManagement.getMeterianGithubEmail() == null ? "bot.github@meterian.io" : testManagement.getMeterianGithubEmail()
         );
-
-        testManagement.configureUnsetUrlRewriting();
 
         // When: the meterian client is run against the locally cloned git repo with the autofix feature (--autofix) passed as a CLI arg
         testManagement.runMeterianClientAndReportAnalysis(configuration, jenkinsLogger);

--- a/src/test/java/io/meterian/integration_tests/MeterianClientAutofixFeatureTest.java
+++ b/src/test/java/io/meterian/integration_tests/MeterianClientAutofixFeatureTest.java
@@ -166,6 +166,7 @@ public class MeterianClientAutofixFeatureTest {
                         "[meterian] Aborting, not continuing with rest of the local/remote branch or pull request creation process."
                 }
         );
+        testManagement.deleteRemoteBranch(gitRepoWorkingFolder, fixedByMeterianBranchName);
     }
 
     @Test

--- a/src/test/java/io/meterian/integration_tests/MeterianClientAutofixFeatureTest.java
+++ b/src/test/java/io/meterian/integration_tests/MeterianClientAutofixFeatureTest.java
@@ -61,7 +61,7 @@ public class MeterianClientAutofixFeatureTest {
         // Given: we are setup to run the meterian client against a repo that has vulnerabilities
         FileUtils.deleteDirectory(new File(gitRepoRootFolder));
         new File(gitRepoRootFolder).mkdir();
-        testManagement.performCloneGitRepo(githubOrgName, githubProjectName, gitRepoRootFolder, "master");
+        testManagement.performCloneGitRepo(githubOrgName, githubProjectName, gitRepoWorkingFolder, "master");
 
         // Deleting remote branch automatically closes any Pull Request attached to it
         testManagement.configureGitUserNameAndEmail(
@@ -69,7 +69,7 @@ public class MeterianClientAutofixFeatureTest {
                 testManagement.getMeterianGithubEmail() == null ? "bot.github@meterian.io" : testManagement.getMeterianGithubEmail()
         );
         fixedByMeterianBranchName = testManagement.getFixedByMeterianBranchName(gitRepoWorkingFolder,"master");
-        testManagement.deleteRemoteBranch(fixedByMeterianBranchName);
+        testManagement.deleteRemoteBranch(gitRepoWorkingFolder, fixedByMeterianBranchName);
 
         // When: the meterian client is run against the locally cloned git repo with the autofix feature (--autofix) passed as a CLI arg
         testManagement.runMeterianClientAndReportAnalysis(configuration, jenkinsLogger);
@@ -174,7 +174,7 @@ public class MeterianClientAutofixFeatureTest {
         FileUtils.deleteDirectory(new File(gitRepoRootFolder));
         new File(gitRepoRootFolder).mkdir();
         testManagement.performCloneGitRepo(
-                githubOrgName, githubProjectName, gitRepoRootFolder, "partially-fixed-by-autofix");
+                githubOrgName, githubProjectName, gitRepoWorkingFolder, "partially-fixed-by-autofix");
 
         // Deleting remote branch automatically closes any Pull Request attached to it
         testManagement.configureGitUserNameAndEmail(
@@ -217,6 +217,7 @@ public class MeterianClientAutofixFeatureTest {
         LocalGitClient gitClient = new LocalGitClient(
                 environment.get("WORKSPACE"),
                 testManagement.getMeterianGithubUser(),
+                testManagement.getMeterianGithubToken(),
                 testManagement.getMeterianGithubEmail(),
                 jenkinsLogger
         );

--- a/src/test/java/io/meterian/integration_tests/MeterianClientAutofixFeatureTest.java
+++ b/src/test/java/io/meterian/integration_tests/MeterianClientAutofixFeatureTest.java
@@ -73,8 +73,15 @@ public class MeterianClientAutofixFeatureTest {
                 testManagement.getMeterianGithubUser() == null ? "meterian-bot" : testManagement.getMeterianGithubUser(),
                 testManagement.getMeterianGithubEmail() == null ? "bot.github@meterian.io" : testManagement.getMeterianGithubEmail()
         );
+
+        testManagement.configureUnsetUrlRewriting();
+
         fixedByMeterianBranchName = testManagement.getFixedByMeterianBranchName(gitRepoWorkingFolder,"master");
-        testManagement.deleteRemoteBranch(gitRepoWorkingFolder, fixedByMeterianBranchName);
+        testManagement.deleteRemoteBranch(
+                gitRepoWorkingFolder,
+                githubOrgName,
+                githubProjectName,
+                fixedByMeterianBranchName);
 
         // When: the meterian client is run against the locally cloned git repo with the autofix feature (--autofix) passed as a CLI arg
         testManagement.runMeterianClientAndReportAnalysis(configuration, jenkinsLogger);
@@ -171,7 +178,12 @@ public class MeterianClientAutofixFeatureTest {
                         "[meterian] Aborting, not continuing with rest of the local/remote branch or pull request creation process."
                 }
         );
-        testManagement.deleteRemoteBranch(gitRepoWorkingFolder, fixedByMeterianBranchName);
+        testManagement.deleteRemoteBranch(
+                gitRepoWorkingFolder,
+                githubOrgName,
+                githubProjectName,
+                fixedByMeterianBranchName
+        );
     }
 
     @Test
@@ -190,6 +202,8 @@ public class MeterianClientAutofixFeatureTest {
                 testManagement.getMeterianGithubUser() == null ? "meterian-bot" : testManagement.getMeterianGithubUser(),
                 testManagement.getMeterianGithubEmail() == null ? "bot.github@meterian.io" : testManagement.getMeterianGithubEmail()
         );
+
+        testManagement.configureUnsetUrlRewriting();
 
         // When: the meterian client is run against the locally cloned git repo with the autofix feature (--autofix) passed as a CLI arg
         testManagement.runMeterianClientAndReportAnalysis(configuration, jenkinsLogger);

--- a/src/test/java/io/meterian/integration_tests/MeterianClientTest.java
+++ b/src/test/java/io/meterian/integration_tests/MeterianClientTest.java
@@ -44,8 +44,8 @@ public class MeterianClientTest {
         new File(gitRepoRootFolder).mkdir();
 
         testManagement.performCloneGitRepo(
-                "MeterianHQ",
                 "autofix-sample-maven-upgrade",
+                "MeterianHQ",
                 gitRepoRootFolder,
                 "master");
     }

--- a/src/test/java/io/meterian/test_management/TestManagement.java
+++ b/src/test/java/io/meterian/test_management/TestManagement.java
@@ -18,8 +18,6 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.output.NullOutputStream;
 import org.apache.http.client.HttpClient;
 import org.eclipse.jgit.api.Git;
-import com.jcraft.jsch.Session;
-import org.eclipse.jgit.api.TransportConfigCallback;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.transport.*;
 import org.jenkinsci.plugins.workflow.steps.StepContext;

--- a/src/test/java/io/meterian/test_management/TestManagement.java
+++ b/src/test/java/io/meterian/test_management/TestManagement.java
@@ -179,10 +179,12 @@ public class TestManagement {
                     .setRefSpecs(refSpec)
                     .setRemote("origin")
                     .call();
+            log.info(String.format("Successfully removed remote branch %s from the repo", branchName));
         } catch (IOException | GitAPIException ex) {
             log.warn(
                     String.format("We were unable to remove a remote branch %s from the repo, " +
-                            "maybe the branch does not exist or the name has changed", branchName));
+                            "maybe the branch does not exist or the name has changed", branchName)
+            );
         }
     }
 

--- a/src/test/java/io/meterian/test_management/TestManagement.java
+++ b/src/test/java/io/meterian/test_management/TestManagement.java
@@ -17,7 +17,11 @@ import java.util.Map;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.output.NullOutputStream;
 import org.apache.http.client.HttpClient;
+import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.transport.CredentialsProvider;
+import org.eclipse.jgit.transport.RefSpec;
+import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import static org.mockito.Mockito.*;
 import org.slf4j.Logger;
@@ -48,6 +52,7 @@ public class TestManagement {
     private PrintStream jenkinsLogger;
     private EnvVars environment;
     private LocalGitClient gitClient;
+    private CredentialsProvider credentialsProvider;
 
     public TestManagement(String gitRepoWorkingFolder,
                           Logger log,
@@ -130,19 +135,20 @@ public class TestManagement {
                 exitCode, exitCode, is(equalTo(0)));
     }
 
-    public void performCloneGitRepo(String githubOrgOrUserName, String githubProjectName, String workingFolder, String branch) throws IOException {
-        String[] gitCloneRepoCommand = new String[] {
-                "git",
-                "clone",
-                String.format("git@github.com:%s/%s.git", githubOrgOrUserName, githubProjectName), // only use ssh or git protocol and not https - uses ssh keys to authenticate
-                "-b",
-                branch
-        };
-
-        int exitCode = runCommand(gitCloneRepoCommand, workingFolder, log);
-
-        assertThat("Cannot run the test, as we were unable to clone the target git repo due to error code: " +
-                exitCode, exitCode, is(equalTo(0)));
+    public void performCloneGitRepo(String githubOrgOrUserName, String githubProjectName, String workingFolder, String branch) {
+        String repoURI = String.format(
+                "git@github.com:%s/%s.git", githubOrgOrUserName, githubProjectName);
+        try {
+            Git.cloneRepository()
+                    .setCredentialsProvider(credentialsProvider)
+                    .setURI(repoURI)
+                    .setBranch(branch)
+                    .setDirectory(new File(workingFolder))
+                    .call();
+        } catch (Exception ex) {
+            fail(String.format("Cannot run the test, as we were unable to clone the target git repo due to an error: %s (cause: %s)",
+                    ex.getMessage(), ex.getCause()));
+        }
     }
 
     public boolean branchExists(String branchName) throws GitAPIException {
@@ -162,18 +168,20 @@ public class TestManagement {
                         .replace("refs/heads/", ""))));
     }
 
-    public void deleteRemoteBranch(String branchName) throws IOException {
-        String[] gitCloneRepoCommand = new String[] {
-                "git",
-                "push",
-                "origin",
-                ":" + branchName
-        };
-
-        int exitCode = runCommand(gitCloneRepoCommand, gitRepoWorkingFolder, log);
-
-        if (exitCode != 0) {
-            jenkinsLogger.println(String.format("We were unable to remove a remote branch %s from the repo, " +
+    public void deleteRemoteBranch(String workingFolder, String branchName) {
+        try {
+            Git git = Git.open(new File(workingFolder));
+            RefSpec refSpec = new RefSpec()
+                    .setSource(null)
+                    .setDestination("refs/heads/" + branchName);
+            git.push()
+                    .setCredentialsProvider(credentialsProvider)
+                    .setRefSpecs(refSpec)
+                    .setRemote("origin")
+                    .call();
+        } catch (IOException | GitAPIException ex) {
+            log.warn(
+                    String.format("We were unable to remove a remote branch %s from the repo, " +
                             "maybe the branch does not exist or the name has changed", branchName));
         }
     }
@@ -183,6 +191,7 @@ public class TestManagement {
             LocalGitClient gitClient = new LocalGitClient(
                     repoWorkspace,
                     getMeterianGithubUser(),
+                    getMeterianGithubToken(),
                     getMeterianGithubEmail(),
                     jenkinsLogger
             );
@@ -199,6 +208,10 @@ public class TestManagement {
 
     public String getMeterianGithubUser() {
         return getOSEnvSettings().get("METERIAN_GITHUB_USER");
+    }
+
+    public String getMeterianGithubToken() {
+        return getOSEnvSettings().get("METERIAN_GITHUB_TOKEN");
     }
 
     public String getMeterianGithubEmail() {
@@ -227,6 +240,10 @@ public class TestManagement {
         if ((meterianGithubEmail == null) || meterianGithubEmail.trim().isEmpty()) {
             jenkinsLogger.println("METERIAN_GITHUB_EMAIL has not been set, tests will be run using the default value assumed for this environment variable");
         }
+
+        // See https://www.codeaffine.com/2014/12/09/jgit-authentication/ for explanation on why this is allowed
+        // First argument of UsernamePasswordCredentialsProvider is the token, the second argument is empty/blank
+        credentialsProvider = new UsernamePasswordCredentialsProvider(meterianGithubToken, "");
 
         MeterianPlugin.Configuration standardConfiguration = new MeterianPlugin.Configuration(
                 BASE_URL,
@@ -317,6 +334,7 @@ public class TestManagement {
             gitClient = new LocalGitClient(
                     gitRepoWorkingFolder,
                     getMeterianGithubUser(),
+                    getMeterianGithubToken(),
                     getMeterianGithubEmail(),
                     jenkinsLogger
             );

--- a/src/test/java/io/meterian/test_management/TestManagement.java
+++ b/src/test/java/io/meterian/test_management/TestManagement.java
@@ -136,19 +136,6 @@ public class TestManagement {
                 exitCode, exitCode, is(equalTo(0)));
     }
 
-    public void configureUnsetUrlRewriting() throws IOException {
-        // git config --global --unset url.ssh://git@github.com.insteadof
-        String[] gitConfigUrlRewriting = new String[] {
-                "git",
-                "config",
-                "--global",
-                "--unset",
-                "url.ssh://git@github.com.insteadof"
-        };
-
-        runCommand(gitConfigUrlRewriting, gitRepoWorkingFolder, log);
-    }
-
     public void performCloneGitRepo(String githubProjectName,
                                     String githubOrgOrUserName,
                                     String workingFolder,

--- a/src/test/java/io/meterian/test_management/TestManagement.java
+++ b/src/test/java/io/meterian/test_management/TestManagement.java
@@ -135,12 +135,16 @@ public class TestManagement {
                 exitCode, exitCode, is(equalTo(0)));
     }
 
-    public void performCloneGitRepo(String githubOrgOrUserName, String githubProjectName, String workingFolder, String branch) {
+    public void performCloneGitRepo(String githubProjectName,
+                                    String githubOrgOrUserName,
+                                    String workingFolder,
+                                    String branch) {
         String repoURI = String.format(
-                "git@github.com:%s/%s.git", githubOrgOrUserName, githubProjectName);
+                "https://github.com/%s/%s.git",
+                githubOrgOrUserName,
+                githubProjectName);
         try {
             Git.cloneRepository()
-                    .setTransportConfigCallback(getTransportConfigCallback())
                     .setCredentialsProvider(credentialsProvider)
                     .setURI(repoURI)
                     .setBranch(branch)
@@ -176,7 +180,6 @@ public class TestManagement {
                     .setSource(null)
                     .setDestination("refs/heads/" + branchName);
             git.push()
-                    .setTransportConfigCallback(getTransportConfigCallback())
                     .setCredentialsProvider(credentialsProvider)
                     .setRefSpecs(refSpec)
                     .setRemote("origin")
@@ -188,18 +191,6 @@ public class TestManagement {
                             "maybe the branch does not exist or the name has changed", branchName)
             );
         }
-    }
-
-    private TransportConfigCallback getTransportConfigCallback() {
-        return transport -> {
-            SshTransport sshTransport = ( SshTransport )transport;
-            sshTransport.setSshSessionFactory( new JschConfigSessionFactory() {
-                @Override
-                protected void configure(OpenSshConfig.Host host, Session session) {
-                    session.setPassword(getMeterianGithubToken());
-                }
-            });
-        };
     }
 
     public String getFixedByMeterianBranchName(String repoWorkspace, String branch) throws Exception {
@@ -257,7 +248,9 @@ public class TestManagement {
             jenkinsLogger.println("METERIAN_GITHUB_EMAIL has not been set, tests will be run using the default value assumed for this environment variable");
         }
 
-        // See https://www.codeaffine.com/2014/12/09/jgit-authentication/ for explanation on why this is allowed
+        // See https://www.codeaffine.com/2014/12/09/jgit-authentication/ or
+        // https://github.blog/2012-09-21-easier-builds-and-deployments-using-git-over-https-and-oauth/
+        // for explanation on why this is allowed
         // First argument of UsernamePasswordCredentialsProvider is the token, the second argument is empty/blank
         credentialsProvider = new UsernamePasswordCredentialsProvider(meterianGithubToken, "");
 


### PR DESCRIPTION
*push not permitted* error when running tests - the cause of this issue was due to CircleCI confi g preventing the creating remote entries for `https` protocols, due to [URL rewriting](https://stackoverflow.com/questions/33835669/jgit-sets-git-uri-instead-of-https-for-remote-on-circleci).

This has now been fixed by removing this config from CircleCI. In addition to the below changes: 

- create docker scripts to emulate isolated environment for running tests
- fix the test setup and LocalGitClient implementation to ensure an https origin is created and used for cloning and pushing changes to remote repo
- always  use the generated PAT (OAuth token) to clone and push (branch) changes to remote repo
- now supports `https` protocol by using PAT (OAuth token) 
- CircleCI: remove Url Rewriting configuration from global scope: `https://` or `git@` ==> `ssh://`

Pending protocols: `git@...` and `ssh://` although in theory should work with the current changes

**Note: our plugin won't be handling such config nuances, hence we would have to notify this via README docs** 